### PR TITLE
docs: fix receive typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ print(response.position)
 
 
 > Note RCL import error
-If you recieve an error such as `version 'GLIBCXX_3.4.30' not found`, you may need to update your gcc version
+If you receive an error such as `version 'GLIBCXX_3.4.30' not found`, you may need to update your gcc version
     ```
     conda install -c conda-forge gcc=12.1.0
     ```


### PR DESCRIPTION
## Problem
The README troubleshooting note has a small typo: "recieve".

## Solution
Corrected it to "receive".

## Validation
- Ran `git diff --check`
- Verified there are no duplicate open PRs matching this typo

## Confidence
Score: 85/100
Category: docs/typo (lower-risk)
