### PR TITLE
Add multi-camera caption support so caption coverage aligns with sensor FOV

### DIFF
--- a/examples/nova_carter_demo/README.md
+++ b/examples/nova_carter_demo/README.md
@@ -290,7 +290,35 @@ Below are details about the ROS nodes used in the demo.  You can check the pytho
 | db_collection | The collection name in MilvusDB to add entries. | "test_collection" |
 | db_ip | The MilvusDB IP address. | "127.0.0.1" |
 | pose_topic | The topic to subscribe to get pose information. | "/amcl_pose" | 
-| caption_topic | The topic to subscribe to get captions. | "/caption" |
+| caption_topics | The topics to subscribe to get captions, one per camera. | ["/caption"] |
+| camera_ids | A camera id per caption topic, stored with each memory entry. | ["front"] |
+| camera_yaw_offsets | Each camera's mounting yaw relative to the robot base, in radians (CCW). | [0.0] |
+
+#### Multi-camera setup
+
+A single front camera only captions a slice of what the robot's sensors
+cover. To align semantic caption coverage with the full sensor FOV, run one
+captioner node per camera (each with its own `image_topic` and
+`caption_topic`) and point a single memory builder at all of them:
+
+```bash
+python python/captioner_node.py --ros-args -p image_topic:=/front_stereo_camera/left/image_raw -p caption_topic:=/caption/front
+python python/captioner_node.py --ros-args -p image_topic:=/left_stereo_camera/left/image_raw -p caption_topic:=/caption/left
+python python/captioner_node.py --ros-args -p image_topic:=/right_stereo_camera/left/image_raw -p caption_topic:=/caption/right
+
+python python/memory_builder_node.py --ros-args \
+    -p caption_topics:="['/caption/front', '/caption/left', '/caption/right']" \
+    -p camera_ids:="['front', 'left', 'right']" \
+    -p camera_yaw_offsets:="[0.0, 1.5708, -1.5708]"
+```
+
+Each stored memory entry then carries the camera id, and its `theta` is the
+caption's actual viewing direction (robot yaw + camera mounting offset,
+wrapped to [-pi, pi]) rather than the robot's base heading, so retrieval and
+downstream reasoning know which way each observation was facing. The
+defaults reproduce the original single front-camera behavior, and
+collections created before multi-camera support keep working (their entries
+simply have no camera id).
 
 ### ASR Node
 

--- a/examples/nova_carter_demo/python/memory_builder_node.py
+++ b/examples/nova_carter_demo/python/memory_builder_node.py
@@ -1,3 +1,5 @@
+import math
+
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import PoseWithCovarianceStamped
@@ -10,6 +12,10 @@ from remembr.memory.memory_policy import StaleDuplicatePolicy
 from common_utils import format_pose_msg
 
 
+def wrap_angle(theta: float) -> float:
+    """Wrap an angle to [-pi, pi]."""
+    return math.atan2(math.sin(theta), math.cos(theta))
+
 
 class MemoryBuilderNode(Node):
 
@@ -20,7 +26,17 @@ class MemoryBuilderNode(Node):
         self.declare_parameter("db_ip", "127.0.0.1")
 
         self.declare_parameter("pose_topic", "/amcl_pose")
-        self.declare_parameter("caption_topic", "/caption")
+
+        # Multi-camera setup: run one captioner node per camera, each
+        # publishing on its own caption topic, and list them here together
+        # with a camera id and the camera's mounting yaw relative to the
+        # robot base (radians, CCW). Stored memories then carry the camera
+        # id, and theta becomes the caption's actual viewing direction, so
+        # semantic caption coverage aligns with the sensor FOV. The defaults
+        # reproduce the original single front-camera behavior.
+        self.declare_parameter("caption_topics", ["/caption"])
+        self.declare_parameter("camera_ids", ["front"])
+        self.declare_parameter("camera_yaw_offsets", [0.0])
 
         # Lifelong memory management: periodically drop stale entries whose
         # caption duplicates a nearby, newer observation.
@@ -37,12 +53,24 @@ class MemoryBuilderNode(Node):
             10
         )
 
-        self.caption_subscriber = self.create_subscription(
-            String,
-            self.get_parameter("caption_topic").value,
-            self.caption_callback,
-            10
-        )
+        caption_topics = list(self.get_parameter("caption_topics").value)
+        camera_ids = list(self.get_parameter("camera_ids").value)
+        camera_yaw_offsets = [float(v) for v in self.get_parameter("camera_yaw_offsets").value]
+        if not (len(caption_topics) == len(camera_ids) == len(camera_yaw_offsets)):
+            raise ValueError(
+                "caption_topics, camera_ids, and camera_yaw_offsets must have the same length "
+                f"(got {len(caption_topics)}, {len(camera_ids)}, {len(camera_yaw_offsets)})")
+
+        self.caption_subscribers = [
+            self.create_subscription(
+                String,
+                topic,
+                self.make_caption_callback(camera_id, yaw_offset),
+                10
+            )
+            for topic, camera_id, yaw_offset
+            in zip(caption_topics, camera_ids, camera_yaw_offsets)
+        ]
         policy = None
         if self.get_parameter("enable_memory_pruning").value:
             policy = StaleDuplicatePolicy(
@@ -65,17 +93,27 @@ class MemoryBuilderNode(Node):
     def pose_callback(self, msg: PoseWithCovarianceStamped):
         self.pose_msg = msg
 
-    def caption_callback(self, msg: String):
+    def make_caption_callback(self, camera_id: str, camera_yaw_offset: float):
+        def caption_callback(msg: String):
+            self.handle_caption(msg, camera_id, camera_yaw_offset)
+        return caption_callback
+
+    def handle_caption(self, msg: String, camera_id: str, camera_yaw_offset: float):
 
         if self.pose_msg is not None:
 
             position, angle, pose_time = format_pose_msg(self.pose_msg)
 
+            # Store the caption's viewing direction, not the base heading,
+            # so retrieved memories point at what the camera actually saw.
+            view_theta = wrap_angle(angle + camera_yaw_offset)
+
             memory = MemoryItem(
                 caption=msg.data,
                 time=pose_time,
                 position=position,
-                theta=angle
+                theta=view_theta,
+                camera_id=camera_id
             )
 
             self.logger.info(f"Added memory item {memory}")

--- a/remembr/memory/memory.py
+++ b/remembr/memory/memory.py
@@ -7,6 +7,10 @@ class MemoryItem:
     time: float
     position: list
     theta: float
+    # Which camera produced the caption ('' when unknown / single-camera).
+    # In multi-camera setups, theta is the viewing direction of this camera
+    # (robot yaw + camera mounting offset), not the robot's base heading.
+    camera_id: str = ''
 
     @classmethod
     def from_dict(cls, dict_input):      
@@ -19,6 +23,8 @@ class MemoryItem:
         # Not every method will use a caption, so we set it to none in those cases
         if self.caption is None:
             self.caption = ''
+        if self.camera_id is None:
+            self.camera_id = ''
 
 
 class Memory:

--- a/remembr/memory/milvus_memory.py
+++ b/remembr/memory/milvus_memory.py
@@ -44,18 +44,23 @@ class MilvusWrapper:
         
         if drop_collection:
             utility.drop_collection(collection_name)
-        
-        fields = [
-            FieldSchema(name='id', dtype=DataType.VARCHAR, description='ids', is_primary=True, auto_id=False, max_length=1000),
-            FieldSchema(name='text_embedding', dtype=DataType.FLOAT_VECTOR, description='embedding vectors', dim=dim),
-            FieldSchema(name='position', dtype=DataType.FLOAT_VECTOR, description='position of robot', dim=3),
-            FieldSchema(name='theta', dtype=DataType.FLOAT, description='rotation of robot', dim=1),
-            FieldSchema(name='time', dtype=DataType.FLOAT_VECTOR, description='time', dim=2),
-            FieldSchema(name='caption', dtype=DataType.VARCHAR, description='caption string', max_length=3000),
 
-        ]
-        schema = CollectionSchema(fields=fields, description='text image search')
-        collection = Collection(name=collection_name, schema=schema)
+        if utility.has_collection(collection_name):
+            # Open existing collections with their stored schema so databases
+            # created before newer fields (e.g. camera_id) keep working.
+            collection = Collection(name=collection_name)
+        else:
+            fields = [
+                FieldSchema(name='id', dtype=DataType.VARCHAR, description='ids', is_primary=True, auto_id=False, max_length=1000),
+                FieldSchema(name='text_embedding', dtype=DataType.FLOAT_VECTOR, description='embedding vectors', dim=dim),
+                FieldSchema(name='position', dtype=DataType.FLOAT_VECTOR, description='position of robot', dim=3),
+                FieldSchema(name='theta', dtype=DataType.FLOAT, description='rotation of robot', dim=1),
+                FieldSchema(name='time', dtype=DataType.FLOAT_VECTOR, description='time', dim=2),
+                FieldSchema(name='caption', dtype=DataType.VARCHAR, description='caption string', max_length=3000),
+                FieldSchema(name='camera_id', dtype=DataType.VARCHAR, description='camera that produced the caption', max_length=100),
+            ]
+            schema = CollectionSchema(fields=fields, description='text image search')
+            collection = Collection(name=collection_name, schema=schema)
 
         # create IVF_FLAT index for collection.
         index_params = {
@@ -137,9 +142,17 @@ class MilvusMemory(Memory):
         self.reset(drop_collection=False)
 
 
+    @property
+    def has_camera_field(self) -> bool:
+        # Collections created before multi-camera support lack the field.
+        return any(f.name == 'camera_id'
+                   for f in self.milv_wrapper.collection.schema.fields)
+
     def insert(self, item: MemoryItem, text_embedding=None):
 
         memory_dict = asdict(item)
+        if not self.has_camera_field:
+            memory_dict.pop('camera_id', None)
         # time alone is not collision-free at high insert rates, so add a uuid
         # suffix to keep primary keys unique and deletions precise
         memory_dict['id'] = f"{time.time()}-{uuid.uuid4().hex[:8]}"
@@ -181,6 +194,8 @@ class MilvusMemory(Memory):
             return []
 
         fields = ['id', 'position', 'theta', 'time', 'caption']
+        if self.has_camera_field:
+            fields.append('camera_id')
         if include_embedding:
             fields.append('text_embedding')
 
@@ -209,6 +224,7 @@ class MilvusMemory(Memory):
                 time=float(row['time'][0]) + self.time_offset,
                 position=list(row['position']),
                 theta=row['theta'],
+                camera_id=row.get('camera_id', ''),
             )
             embedding = list(row['text_embedding']) if include_embedding else None
             records.append(MemoryRecord(id=row['id'], item=item, embedding=embedding))
@@ -381,7 +397,15 @@ class MilvusMemory(Memory):
             t = strftime('%Y-%m-%d %H:%M:%S', t)
 
             s = f"At time={t}, the robot was at an average position of {np.array(doc.metadata['position']).round(3).tolist()}."
-            s += f"The robot saw the following: {doc.page_content}\n\n"
+            camera_id = doc.metadata.get('camera_id', '')
+            if camera_id:
+                theta = doc.metadata.get('theta')
+                if theta is not None:
+                    s += f"Its '{camera_id}' camera was facing {round(float(theta), 3)} radians and saw the following: {doc.page_content}\n\n"
+                else:
+                    s += f"Its '{camera_id}' camera saw the following: {doc.page_content}\n\n"
+            else:
+                s += f"The robot saw the following: {doc.page_content}\n\n"
             out_string += s
         return out_string
 

--- a/remembr/memory/text_memory.py
+++ b/remembr/memory/text_memory.py
@@ -52,6 +52,9 @@ class TextMemory(Memory):
             t = strftime('%Y-%m-%d %H:%M:%S', t)
 
             s = f"At time={t}, the robot was at an average position of {np.array(doc.position).round(3).tolist()} with an average orientation of {doc.theta} radians. "
-            s += f"The robot saw the following: {doc.caption}\n\n"
+            if getattr(doc, 'camera_id', ''):
+                s += f"Its '{doc.camera_id}' camera saw the following: {doc.caption}\n\n"
+            else:
+                s += f"The robot saw the following: {doc.caption}\n\n"
             out_string += s
         return out_string

--- a/remembr/memory/video_memory.py
+++ b/remembr/memory/video_memory.py
@@ -24,7 +24,9 @@ class ImageMemoryItem(MemoryItem):
     time: float
     position: list
     theta: float
-    image: Image.Image
+    # Defaulted because the MemoryItem base ends in defaulted fields
+    # (camera_id) and dataclasses forbid non-default fields after them.
+    image: Image.Image = None
 
 
 class VideoMemory(Memory):

--- a/tests/test_memory_builder_node.py
+++ b/tests/test_memory_builder_node.py
@@ -9,6 +9,7 @@ the policy/prune_every plumbing into MilvusMemory.
 """
 
 import importlib
+import math
 import sys
 import types
 from pathlib import Path
@@ -132,11 +133,12 @@ def make_node(node_module, monkeypatch, milvus_db_address):
         node.memory.milv_wrapper.drop_collection()
 
 
-def make_pose(x, y, t):
+def make_pose(x, y, t, yaw=0.0):
     msg = PoseWithCovarianceStamped()
     msg.pose = SimpleNamespace(pose=SimpleNamespace(
         position=SimpleNamespace(x=x, y=y, z=0.0),
-        orientation=SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)))
+        orientation=SimpleNamespace(x=0.0, y=0.0,
+                                    z=math.sin(yaw / 2.0), w=math.cos(yaw / 2.0))))
     msg.header = SimpleNamespace(stamp=SimpleNamespace(sec=int(t), nanosec=0))
     return msg
 
@@ -150,15 +152,16 @@ def test_node_wiring_and_caption_insert(make_node):
     # Both subscriptions are registered with callbacks that actually exist.
     callbacks = {topic: callback for _, topic, callback in node.subscriptions}
     assert callbacks['/amcl_pose'] == node.pose_callback
-    assert callbacks['/caption'] == node.caption_callback
+    caption_callback = callbacks['/caption']
+    assert callable(caption_callback)
 
     # A caption arriving before any pose is ignored rather than crashing.
-    node.caption_callback(String('i see a desk'))
+    caption_callback(String('i see a desk'))
     assert node.memory.get_all() == []
 
     # pose + caption -> a MemoryItem lands in the DB with the pose's data.
     node.pose_callback(make_pose(1.0, 2.0, T0))
-    node.caption_callback(String('i see a desk'))
+    caption_callback(String('i see a desk'))
     node.memory.milv_wrapper.collection.flush()
 
     records = node.memory.get_all()
@@ -166,6 +169,49 @@ def test_node_wiring_and_caption_insert(make_node):
     assert records[0].item.caption == 'i see a desk'
     assert records[0].item.position == pytest.approx([1.0, 2.0, 0.0])
     assert records[0].item.time == pytest.approx(T0, abs=1.0)
+    # The single-camera default tags entries as the front camera at offset 0.
+    assert records[0].item.camera_id == 'front'
+    assert records[0].item.theta == pytest.approx(0.0)
+
+
+def test_multi_camera_captions_store_camera_id_and_view_direction(make_node):
+    node = make_node(caption_topics=['/caption/front', '/caption/left', '/caption/rear'],
+                     camera_ids=['front', 'left', 'rear'],
+                     camera_yaw_offsets=[0.0, math.pi / 2, math.pi])
+
+    callbacks = {topic: callback for _, topic, callback in node.subscriptions}
+    assert set(callbacks) == {'/amcl_pose', '/caption/front', '/caption/left', '/caption/rear'}
+
+    # Robot facing +90deg; each camera's caption should land at the robot
+    # yaw plus its mounting offset, wrapped to [-pi, pi].
+    node.pose_callback(make_pose(1.0, 2.0, T0, yaw=math.pi / 2))
+    callbacks['/caption/front'](String('a desk ahead'))
+    callbacks['/caption/left'](String('a plant to the left'))
+    callbacks['/caption/rear'](String('a hallway behind'))
+    node.memory.milv_wrapper.collection.flush()
+
+    records = node.memory.get_all()
+    by_camera = {record.item.camera_id: record.item for record in records}
+    assert set(by_camera) == {'front', 'left', 'rear'}
+
+    assert by_camera['front'].caption == 'a desk ahead'
+    assert by_camera['front'].theta == pytest.approx(math.pi / 2)
+    assert by_camera['left'].theta == pytest.approx(math.pi)
+    # pi/2 + pi wraps to -pi/2 rather than growing past pi.
+    assert by_camera['rear'].theta == pytest.approx(-math.pi / 2)
+    # All cameras share the same robot pose.
+    for item in by_camera.values():
+        assert item.position == pytest.approx([1.0, 2.0, 0.0])
+
+
+def test_mismatched_camera_params_are_rejected(node_module, monkeypatch, milvus_db_address):
+    monkeypatch.setattr(FakeNode, 'param_overrides', {
+        'db_collection': COLLECTION, 'db_ip': milvus_db_address,
+        'caption_topics': ['/caption/front', '/caption/rear'],
+        'camera_ids': ['front'],
+        'camera_yaw_offsets': [0.0, 3.14]})
+    with pytest.raises(ValueError, match='same length'):
+        node_module.MemoryBuilderNode()
 
 
 def test_node_pruning_params_reach_the_policy(make_node):
@@ -192,13 +238,15 @@ def test_node_auto_prunes_through_caption_callback(make_node):
                      pruning_position_radius=1.0,
                      pruning_similarity_threshold=0.9)
 
+    caption_callback = {topic: callback for _, topic, callback in node.subscriptions}['/caption']
+
     # Four stale duplicates at the same spot...
     for i in range(4):
         node.pose_callback(make_pose(0.0, 0.0, T0 + i))
-        node.caption_callback(String('i see a desk'))
+        caption_callback(String('i see a desk'))
     # ...then a much newer one; the 5th insert triggers the pruning pass.
     node.pose_callback(make_pose(0.0, 0.0, T0 + 10_000))
-    node.caption_callback(String('i see a desk'))
+    caption_callback(String('i see a desk'))
     node.memory.milv_wrapper.collection.flush()
 
     records = node.memory.get_all()

--- a/tests/test_milvus_memory_policy.py
+++ b/tests/test_milvus_memory_policy.py
@@ -62,6 +62,64 @@ def _insert(memory, caption, t, position=(0.0, 0.0, 0.0)):
     memory.insert(MemoryItem(caption=caption, time=t, position=list(position), theta=0.0))
 
 
+def test_camera_id_roundtrip(memory):
+    from remembr.memory.memory import MemoryItem
+
+    memory.insert(MemoryItem(caption='a plant to the left', time=T0,
+                             position=[0.0, 0.0, 0.0], theta=1.57, camera_id='left'))
+    _insert(memory, 'i see a desk', T0 + 5)  # no camera_id -> stored as ''
+    memory.milv_wrapper.collection.flush()
+
+    by_caption = {r.item.caption: r.item for r in memory.get_all()}
+    assert by_caption['a plant to the left'].camera_id == 'left'
+    assert by_caption['i see a desk'].camera_id == ''
+
+
+def test_insert_into_pre_camera_collection(monkeypatch, milvus_db_address):
+    """Collections created before the camera_id field keep working."""
+
+    from pymilvus import (Collection, CollectionSchema, DataType, FieldSchema,
+                          connections, utility)
+
+    collection_name = 'test_pre_camera_collection'
+
+    if milvus_db_address.endswith('.db'):
+        connections.connect(uri=milvus_db_address)
+    else:
+        connections.connect(host=milvus_db_address, port=MILVUS_PORT)
+    utility.drop_collection(collection_name)
+    legacy_fields = [
+        FieldSchema(name='id', dtype=DataType.VARCHAR, is_primary=True, auto_id=False, max_length=1000),
+        FieldSchema(name='text_embedding', dtype=DataType.FLOAT_VECTOR, dim=1024),
+        FieldSchema(name='position', dtype=DataType.FLOAT_VECTOR, dim=3),
+        FieldSchema(name='theta', dtype=DataType.FLOAT),
+        FieldSchema(name='time', dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name='caption', dtype=DataType.VARCHAR, max_length=3000),
+    ]
+    Collection(name=collection_name, schema=CollectionSchema(fields=legacy_fields))
+
+    import remembr.memory.milvus_memory as milvus_memory_module
+    monkeypatch.setattr(milvus_memory_module, 'HuggingFaceEmbeddings',
+                        lambda model_name: FakeEmbedder())
+    from remembr.memory.memory import MemoryItem
+    from remembr.memory.milvus_memory import MilvusMemory
+
+    memory = MilvusMemory(collection_name, db_ip=milvus_db_address, db_port=MILVUS_PORT)
+    try:
+        assert not memory.has_camera_field
+        # camera_id is silently dropped instead of failing the insert
+        memory.insert(MemoryItem(caption='i see a desk', time=T0,
+                                 position=[0.0, 0.0, 0.0], theta=0.0, camera_id='front'))
+        memory.milv_wrapper.collection.flush()
+
+        records = memory.get_all()
+        assert len(records) == 1
+        assert records[0].item.caption == 'i see a desk'
+        assert records[0].item.camera_id == ''
+    finally:
+        memory.milv_wrapper.drop_collection()
+
+
 def test_get_all_on_empty_collection(memory):
     # Regression: vector output fields on an empty collection crash
     # milvus-lite; get_all must probe first and return [].


### PR DESCRIPTION
## Summary

A single front camera only captions a slice of what the robot's sensors cover. This PR lets captions come from any number of cameras so semantic caption coverage roughly aligns with the sensor FOV:

- `MemoryItem` gains an optional `camera_id` (default `''`, fully backward compatible).
- The nova_carter memory builder node takes parallel `caption_topics` / `camera_ids` / `camera_yaw_offsets` parameters (validated to be the same length). Each stored entry's `theta` becomes the caption's actual viewing direction — robot yaw + camera mounting offset, wrapped to [-pi, pi] — rather than the robot's base heading. Defaults reproduce the original single front-camera behavior.
- The captioner node is unchanged: run one instance per camera on its own image/caption topics (example commands added to the demo README).
- Milvus collections gain a `camera_id` field. Existing collections are opened with their stored schema and detected via `has_camera_field`, so pre-existing databases keep working without migration.
- `memory_to_string` (Milvus and text memory) now tells the agent LLM which camera saw each observation and its facing angle.

Note: `ImageMemoryItem.image` now defaults to `None` because dataclasses forbid non-default fields after the defaulted `camera_id` in the base class; it is only ever constructed via `from_dict` keywords, so this is safe.

Stacked on #29 (uses its `MemoryRecord`/`get_all` plumbing), hence based on `lifelong-memory-management`.

## Testing

Full suite passes (47 tests, Milvus Lite backend), including new tests for:
- multi-camera wiring: per-topic callbacks, theta composition and wrapping, shared robot pose
- mismatched-length camera parameter rejection
- `camera_id` round-trip through Milvus
- inserting into a legacy collection created before the `camera_id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)